### PR TITLE
Distributed groupby sum operation

### DIFF
--- a/sparsity/dask/multi.py
+++ b/sparsity/dask/multi.py
@@ -6,9 +6,8 @@ import pandas as pd
 from dask.dataframe.multi import require, required
 from sparsity.dask.core import SparseFrame
 from functools import partial
-from dask.dataframe.core import is_broadcastable, _Frame
+from dask.dataframe.core import is_broadcastable, _Frame, aca
 from toolz import unique, merge_sorted
-
 
 
 def join_indexed_sparseframes(lhs, rhs, how='left'):

--- a/sparsity/sparse_frame.py
+++ b/sparsity/sparse_frame.py
@@ -129,7 +129,9 @@ class SparseFrame(object):
                 dense = pd.DataFrame(dense.reshape(1, -1), index=self.index,
                                      columns=self.columns)
             else:
-                idx = np.broadcast_to(self.index, dense.shape[0])
+                # need to copy as broadcast_to return read_only array
+                idx = np.broadcast_to(self.index, dense.shape[0])\
+                     .copy()
                 dense = pd.DataFrame(dense, index=idx,
                                      columns=self.columns)
         return dense

--- a/sparsity/test/test_dask_sparse_frame.py
+++ b/sparsity/test/test_dask_sparse_frame.py
@@ -272,3 +272,20 @@ def test_distributed_join(how):
     res = joined.compute().todense()
 
     pdt.assert_frame_equal(correct, res)
+
+
+def test_groupby_sum():
+    df = pd.DataFrame(dict(A=np.ones(100), B=np.ones(100)),
+                      index=list('ABCD'*25))
+    correct = df.groupby(level=0).sum()
+    correct.sort_index(inplace=True)
+
+    spf = dsp.from_pandas(df, npartitions=2)
+    assert spf.npartitions == 2
+    grouped = spf.groupby_sum(split_out=4)
+
+    assert grouped.npartitions == 4
+    res = grouped.compute().todense()
+    res.sort_index(inplace=True)
+
+    pdt.assert_frame_equal(res, correct)

--- a/sparsity/test/test_dask_sparse_frame.py
+++ b/sparsity/test/test_dask_sparse_frame.py
@@ -273,10 +273,15 @@ def test_distributed_join(how):
 
     pdt.assert_frame_equal(correct, res)
 
+@pytest.mark.parametrize('idx', [
+    list('ABCD'*25),
+    np.array(list('0123'*25)).astype(int),
+    np.array(list('0123'*25)).astype(float),
+])
+def test_groupby_sum(idx):
 
-def test_groupby_sum():
     df = pd.DataFrame(dict(A=np.ones(100), B=np.ones(100)),
-                      index=list('ABCD'*25))
+                      index=idx)
     correct = df.groupby(level=0).sum()
     correct.sort_index(inplace=True)
 


### PR DESCRIPTION
This was a difficult one...but crucial step to scaling our binning algorithm. Finally it seems to be working also fixed a little bug along the way.

It works roughly like this:
1) apply groupy_sum on each partition
2) hash index and partition into n unique (index) partitions (so each index hashed value is in it"s own partition)
3) concat these mini partitions into number of desired partitions 
4) finally apply groupby_sum on newly formed partitions

This should fix the trouble we had with huge test datasets of a single partitions. So we can predict with dask_xgboost now. it also should allow us to train on much more data. Given we have a cluster.