### PR TITLE
Drop support for pandas>=0.23.0 as api changes break iloc functionality

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     packages=packages,
     cmdclass=versioneer.get_cmdclass(),
     install_requires=[
-                        'pandas>=0.19.0',
+                        'pandas>=0.19.0,<0.23.0',
                         'scipy>=0.18.1',
                         'numpy>=1.12.0',
                         's3fs>=0.1.0'


### PR DESCRIPTION
Until we figure out how to incorporate pandas API changes in 0.23.0 this fixes the broken iloc.