### PR TITLE
Fix init from pd.DataFrame with passed index/columns

### DIFF
--- a/sparsity/sparse_frame.py
+++ b/sparsity/sparse_frame.py
@@ -85,12 +85,14 @@ class SparseFrame(object):
                              'indices imply {}'
                              .format(data.shape, (implied_axis_0, len(columns))))
         else:
-            # assert len(columns) == K
             self._columns = _ensure_index(columns)
 
         if not sparse.isspmatrix_csr(data):
             try:
-                self._init_values(data, kwargs)
+                self._init_values(data,
+                                  init_index=index is None,
+                                  init_columns=columns is None,
+                                  **kwargs)
             except TypeError:
                 raise TypeError(traceback.format_exc() +
                                 "\nThe error described above occurred while "
@@ -113,12 +115,22 @@ class SparseFrame(object):
                 _indexer = functools.partial(indexer, name=name)
             setattr(cls, name, property(_indexer, doc=indexer.__doc__))
 
-    def _init_values(self, data, kwargs):
+    def _init_values(self, data, init_index=True, init_columns=True, **kwargs):
         if isinstance(data, pd.DataFrame):
             self.empty = data.empty
             self._init_csr(sparse.csr_matrix(data.values))
-            self._index = _ensure_index(data.index)
-            self._columns = _ensure_index(data.columns)
+            if init_index:
+                self._index = _ensure_index(data.index)
+            else:
+                warnings.warn("Passed index explicitly while initializing "
+                              "from pd.DataFrame. Original DataFrame's index "
+                              "will be ignored.", SyntaxWarning)
+            if init_columns:
+                self._columns = _ensure_index(data.columns)
+            else:
+                warnings.warn("Passed columns explicitly while initializing "
+                              "from pd.DataFrame. Original DataFrame's columns"
+                              " will be ignored.", SyntaxWarning)
         elif _is_empty(data):
             self.empty = True
             self._data = sparse.csr_matrix((len(self.index),

--- a/sparsity/test/test_sparse_frame.py
+++ b/sparsity/test/test_sparse_frame.py
@@ -749,7 +749,13 @@ def test_init_with_pandas():
     sf = SparseFrame(df)
     assert sf.shape == (5, 5)
     assert isinstance(sf.index, pd.MultiIndex)
-    assert sf.columns.tolist() == list('ABCDE')
+    assert (sf.index == df.index).all()
+    assert (sf.columns == df.columns).all()
+
+    with pytest.warns(SyntaxWarning):
+        sf = SparseFrame(df, index=np.arange(10, 15), columns=list('VWXYZ'))
+    assert sf.index.tolist() == np.arange(10, 15).tolist()
+    assert sf.columns.tolist() == list('VWXYZ')
 
     s = pd.Series(np.ones(10))
     sf = SparseFrame(s)


### PR DESCRIPTION
Previously original DataFrame's index/columns would be preserved
and passed index/columns would be ignored.

Now passed index/columns are used but a SyntaxWarning is issued.

Fixes #52.