### PR TITLE
Leave some columns untouched when one-hot-encoding

### DIFF
--- a/sparsity/dask/reshape.py
+++ b/sparsity/dask/reshape.py
@@ -6,7 +6,7 @@ from sparsity.dask import SparseFrame
 
 
 def one_hot_encode(ddf, column=None, categories=None, index_col=None,
-                   order=None, prefixes=False,
+                   order=None, prefixes=False, sep='_',
                    ignore_cat_order_mismatch=False):
     """
     Sparse one hot encoding of dask.DataFrame.
@@ -49,9 +49,12 @@ def one_hot_encode(ddf, column=None, categories=None, index_col=None,
         so that new columns will be named like:
         [cat11, cat12, cat21, cat22, ...].
 
-        If True, original column name followed by an underscore will be added
+        If True, original column name followed by a separator will be added
         in front of each category name, so that new columns will be named like:
         [col1_cat11, col1_cat12, col2_cat21, col2_cat22, ...].
+        See ``sep`` argument.
+    sep: str
+        Separator used when ``prefixes`` is True.
     column: DEPRECATED
         Kept only for backward compatibility.
     ignore_cat_order_mismatch: bool
@@ -78,6 +81,7 @@ def one_hot_encode(ddf, column=None, categories=None, index_col=None,
                              index_col=index_col,
                              order=order,
                              prefixes=prefixes,
+                             sep=sep,
                              ignore_cat_order_mismatch=ignore_cat_order_mismatch
                              ).columns
     meta = sp.SparseFrame(np.empty(shape=(0, len(columns))), columns=columns,
@@ -89,6 +93,7 @@ def one_hot_encode(ddf, column=None, categories=None, index_col=None,
                              index_col=index_col,
                              order=order,
                              prefixes=prefixes,
+                             sep=sep,
                              ignore_cat_order_mismatch=ignore_cat_order_mismatch,
                              meta=object)
 

--- a/sparsity/sparse_frame.py
+++ b/sparsity/sparse_frame.py
@@ -1103,7 +1103,7 @@ def _create_group_matrix(group_idx, dtype='f8'):
 
 
 def sparse_one_hot(df, column=None, categories=None, dtype='f8',
-                   index_col=None, order=None, prefixes=False,
+                   index_col=None, order=None, prefixes=False, sep='_',
                    ignore_cat_order_mismatch=False):
     """
     One-hot encode specified columns of a pandas.DataFrame.
@@ -1152,7 +1152,8 @@ def sparse_one_hot(df, column=None, categories=None, dtype='f8',
                 ignore_cat_order_mismatch=ignore_cat_order_mismatch
             )
             if prefixes:
-                cols = list(map(lambda x: '{}_{}'.format(column, x), cols))
+                column_tmpl = ''.join((column, sep, '{}'))
+                cols = list(map(column_tmpl.format, map(str, cols)))
         new_cols.extend(cols)
         csrs.append(csr)
     if len(set(new_cols)) < len(new_cols):

--- a/sparsity/sparse_frame.py
+++ b/sparsity/sparse_frame.py
@@ -1,12 +1,12 @@
 # coding=utf-8
+import functools
 import traceback
 import warnings
 from collections import OrderedDict
+from functools import partial, reduce
 
-import functools
 import numpy as np
 import pandas as pd
-from functools import partial, reduce
 from pandas.api import types
 from pandas.core.common import _default_index
 
@@ -1141,6 +1141,10 @@ def sparse_one_hot(df, column=None, categories=None, dtype='f8',
     for column, column_cat in categories.items():
         if column_cat is False:
             # this column is skipped - we don't ohe it
+            if not np.issubdtype(df.dtypes[column], np.number):
+                raise TypeError(f"Column `{column}` is not of numerical dtype, "
+                                f"but was requested to be included untouched "
+                                f"in a sparse one-hot-encoded frame.")
             cols = [column]
             csr = sparse.csr_matrix(df[[column]].values)
         else:

--- a/sparsity/sparse_frame.py
+++ b/sparsity/sparse_frame.py
@@ -1178,15 +1178,14 @@ def _one_hot_series_csr(categories, dtype, oh_col,
                                 ignore_cat_order_mismatch)
 
     else:
-        s = oh_col
-        cat = pd.Categorical(s, np.asarray(categories))
+        cat = pd.Categorical(oh_col, np.asarray(categories))
     codes = cat.codes
     n_features = len(cat.categories)
     n_samples = codes.size
     mask = codes != -1
     if np.any(~mask):
         raise ValueError("Unknown categorical features present "
-                         "during transform: %s." % np.unique(s[~mask]))
+                         "during transform: %s." % np.unique(oh_col[~mask]))
     row_indices = np.arange(n_samples, dtype=np.int32)
     col_indices = codes
     data = np.ones(row_indices.size)

--- a/sparsity/test/conftest.py
+++ b/sparsity/test/conftest.py
@@ -1,14 +1,13 @@
 import os
-import shutil
 import tempfile
 from contextlib import contextmanager
 
 import numpy as np
 import pandas as pd
 import pytest
+import shutil
+
 import sparsity
-
-
 # 2017 starts with a sunday
 from sparsity import SparseFrame
 
@@ -87,12 +86,14 @@ def testdb():
 
 @pytest.fixture()
 def clickstream():
-    df = pd.DataFrame(dict(
-        page_id=np.random.choice(list('ABCDE'), size=100),
-        other_categorical=np.random.choice(list('FGHIJ'), size=100),
-        id=np.random.choice([1,2,3,4,5,6,7,8,9], size=100)
+    df = pd.DataFrame(
+        dict(
+            page_id=np.random.choice(list('ABCDE'), size=100),
+            other_categorical=np.random.choice(list('FGHIJ'), size=100),
+            id=np.random.choice([1,2,3,4,5,6,7,8,9], size=100)
         ),
-    index=pd.date_range("2016-01-01", periods=100))
+        index=pd.date_range("2016-01-01", periods=100),
+    )
     return df
 
 

--- a/sparsity/test/test_dask_sparse_frame.py
+++ b/sparsity/test/test_dask_sparse_frame.py
@@ -221,6 +221,18 @@ def test_one_hot_prefixes(clickstream):
     assert sorted(sf.columns) == sorted(correct_columns)
 
 
+def test_one_hot_prefixes_sep(clickstream):
+    ddf = dd.from_pandas(clickstream, npartitions=10)
+    dsf = one_hot_encode(ddf,
+                         categories={'page_id': list('ABCDE'),
+                                     'other_categorical': list('FGHIJ')},
+                         index_col=['index', 'id'],
+                         prefixes=True, sep='=')
+    correct_columns = list(map(lambda x: 'page_id=' + x, list('ABCDE'))) \
+        + list(map(lambda x: 'other_categorical=' + x, list('FGHIJ')))
+    assert sorted(dsf.columns) == sorted(correct_columns)
+
+
 def test_one_hot_order1(clickstream):
     ddf = dd.from_pandas(clickstream, npartitions=10)
     dsf = one_hot_encode(ddf,

--- a/sparsity/test/test_dask_sparse_frame.py
+++ b/sparsity/test/test_dask_sparse_frame.py
@@ -251,6 +251,20 @@ def test_one_hot_order2(clickstream):
     assert all(sf.columns == list('FGHIJABCDE'))
 
 
+def test_one_hot_dense_column(clickstream):
+    ddf = dd.from_pandas(clickstream, npartitions=10)
+    dsf = one_hot_encode(ddf,
+                         categories={'page_id': list('ABCDE'),
+                                     'other_categorical': list('FGHIJ'),
+                                     'id': False},
+                         )
+    assert dsf._meta.empty
+    assert set(dsf.columns) == set('ABCDEFGHIJ') | {'id'}
+    sf = dsf.compute()
+    assert sf.shape == (100, 11)
+    assert set(sf.columns) == set('ABCDEFGHIJ') | {'id'}
+
+
 def test_one_hot_disk_categories(clickstream):
     with tmpdir() as tmp:
         cat_path = os.path.join(tmp, 'cat.pickle')

--- a/sparsity/test/test_sparse_frame.py
+++ b/sparsity/test/test_sparse_frame.py
@@ -537,6 +537,19 @@ def test_csr_one_hot_series_prefixes(sampledata, weekdays, weekdays_abbr):
     assert all(sparse_frame.columns == correct_columns)
 
 
+def test_csr_one_hot_series_prefixes_sep(sampledata, weekdays, weekdays_abbr):
+    categories = {'weekday': weekdays,
+                  'weekday_abbr': weekdays_abbr}
+
+    sparse_frame = sparse_one_hot(sampledata(49), categories=categories,
+                                  order=['weekday', 'weekday_abbr'],
+                                  prefixes=True, sep='=')
+
+    correct_columns = list(map(lambda x: 'weekday=' + x, weekdays)) \
+        + list(map(lambda x: 'weekday_abbr=' + x, weekdays_abbr))
+    assert all(sparse_frame.columns == correct_columns)
+
+
 def test_csr_one_hot_series_same_categories(weekdays):
     sample_data = pd.DataFrame(
         dict(date=pd.date_range("2017-01-01", periods=7)))

--- a/sparsity/test/test_sparse_frame.py
+++ b/sparsity/test/test_sparse_frame.py
@@ -1,8 +1,8 @@
 # coding=utf-8
+import datetime as dt
 import os
 from contextlib import contextmanager
 
-import datetime as dt
 import numpy as np
 import pandas as pd
 import pandas.testing as pdt
@@ -613,6 +613,22 @@ def test_csr_one_hot_series_dense_column(sampledata, weekdays, weekdays_abbr):
         == set(weekdays + weekdays_abbr + ['dense'])
     assert np.all(res[weekdays + weekdays_abbr] == correct_without_dense)
     assert (sparse_frame['dense'].todense() == data['dense']).all()
+
+
+def test_csr_one_hot_series_dense_column_non_numeric(sampledata, weekdays,
+                                                     weekdays_abbr):
+    data = sampledata(49, categorical=True)
+    data['dense'] = np.random.choice(list('abc'), len(data))
+
+    categories = {
+        'weekday': None,
+        'weekday_abbr': None,
+        'dense': False,
+    }
+
+    with pytest.raises(TypeError,
+                       match='Column `dense` is not of numerical dtype'):
+        sparse_one_hot(data, categories=categories)
 
 
 def test_npz_io(complex_example):

--- a/sparsity/test/test_sparse_frame.py
+++ b/sparsity/test/test_sparse_frame.py
@@ -1,18 +1,17 @@
 # coding=utf-8
-import datetime as dt
 import os
-
 from contextlib import contextmanager
 
+import datetime as dt
 import numpy as np
 import pandas as pd
 import pandas.testing as pdt
 import pytest
 from moto import mock_s3
 from scipy import sparse
+
 from sparsity import SparseFrame, sparse_one_hot
 from sparsity.io_ import _csr_to_dict
-
 from .conftest import tmpdir
 
 
@@ -488,6 +487,28 @@ def test_csr_one_hot_series_other_order(sampledata, weekdays, weekdays_abbr):
     assert all(sparse_frame.columns == (weekdays_abbr + weekdays))
 
 
+def test_csr_one_hot_series_no_categories(sampledata, weekdays, weekdays_abbr):
+
+    data = sampledata(49, categorical=True).drop('date', axis=1)
+    sparse_frame = sparse_one_hot(data)
+
+    assert set(sparse_frame.columns) \
+        == set(weekdays_abbr) | set(weekdays) | {'id'}
+
+
+def test_csr_one_hot_series_wrong_order(sampledata, weekdays, weekdays_abbr):
+
+    categories = {'weekday': weekdays,
+                  'weekday_abbr': weekdays_abbr}
+
+    with pytest.raises(AssertionError):
+        sparse_one_hot(sampledata(49), categories=categories,
+                       order=['weekday_abbr', 'weekday', 'wat'])
+    with pytest.raises(AssertionError):
+        sparse_one_hot(sampledata(49), categories=categories,
+                       order=['weekday_abbr'])
+
+
 def test_csr_one_hot_series_no_order(sampledata, weekdays, weekdays_abbr):
 
     categories = {'weekday': weekdays,
@@ -557,6 +578,28 @@ def test_csr_one_hot_series_too_little_categories(sampledata):
                   'Thursday', 'Friday']
     with pytest.raises(ValueError):
         sparse_one_hot(sampledata(49), categories={'weekday': categories})
+
+
+def test_csr_one_hot_series_dense_column(sampledata, weekdays, weekdays_abbr):
+    correct_without_dense = np.hstack((np.identity(7) * 7,
+                                       np.identity(7) * 7))
+
+    data = sampledata(49, categorical=True)
+    data['dense'] = np.random.rand(len(data))
+
+    categories = {
+        'weekday': None,
+        'weekday_abbr': None,
+        'dense': False,
+    }
+
+    sparse_frame = sparse_one_hot(data, categories=categories)
+
+    res = sparse_frame.groupby_sum(np.tile(np.arange(7), 7)).todense()
+    assert set(sparse_frame.columns) \
+        == set(weekdays + weekdays_abbr + ['dense'])
+    assert np.all(res[weekdays + weekdays_abbr] == correct_without_dense)
+    assert (sparse_frame['dense'].todense() == data['dense']).all()
 
 
 def test_npz_io(complex_example):


### PR DESCRIPTION
TODOs:
- [x] add a check if untouched column is numerical in sparsity/sparse_frame.py (`if column_cat is False: ...`